### PR TITLE
Fix copy-paste mistake in README

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,3 +1,3 @@
 # Coding Samples
 
-Small samples from various programming/markup/config languages to check how Catppuccin looks on them.
+Small samples from various programming/markup/config languages to check how oxocarbon looks on them.


### PR DESCRIPTION
The README in the samples folder still has the Catppuccin theme mentioned, probably because it was copied from there.