### PR TITLE
Add micro

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@ Discussion primarily takes place on the Nyoom Engineering discord server
 
 - [base16](https://github.com/nyoom-engineering/base16-oxocarbon)
 - [nvim](https://github.com/nyoom-engineering/oxocarbon.nvim)
+- [micro](https://github.com/StikyPiston/oxocarbon-micro)

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,3 +1,3 @@
 # Coding Samples
 
-Small samples from various programming/markup/config languages to check how Catppuccin looks on them.
+Small samples from various programming/markup/config languages to check how Oxocarbon looks on them.


### PR DESCRIPTION
This is a port of the Oxocarbon theme to the Micro text editor.
Link: https://github.com/StikyPiston/oxocarbon-micro

Changed `samples/README.md` to say 'Oxocarbon' instead of 'Catppuccin'