### PR TITLE
Add a Ghostty port

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ For software where an official port is unavailable, our thriving community steps
 * [[Dark] Konsole](https://github.com/code0x378/oxocarbon-konsole)
 * [[Dark] ST](https://gist.github.com/xStormyy/f6d5316a395091f1de57e42ac0492632)
 * [[Dark] Warp](https://github.com/Takk8IS/oxocarbon-theme-for-warp)
+* [[Dark] Ghostty](https://github.com/Axiol/oxocarbon-ghostty)
 
 </details>
 


### PR DESCRIPTION
I created a port for Ghostty https://github.com/Axiol/oxocarbon-ghostty. Only the dark version is implemented right now. But I plan on doing a white version when I'll get some time to look into it